### PR TITLE
Add backend endpoint for search filtering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,33 +237,34 @@ All params are **optional** and **combinable**.
 > Pagination: **not implemented yet**. You’ll get the full filtered list.
 
 **Quick Examples**
-Basic Keyword Search:
-/api/restaurants/filter?query=sushi
 
-By cuisine:
-/api/restaurants/filter?cuisine=Italian
+- Basic Keyword Search:
+  /api/restaurants/filter?query=sushi
 
-Price range:
-/api/restaurants/filter?priceMin=2&priceMax=4
+- By cuisine:
+  /api/restaurants/filter?cuisine=Italian
 
-Reservation Required:
-/api/restaurants/filter?reservation=true
+- Price range:
+  /api/restaurants/filter?priceMin=2&priceMax=4
 
-Open Now (NZ time):
-api/restaurants/filter?openNow=true
+- Reservation Required:
+  /api/restaurants/filter?reservation=true
 
-Filter by one city:
-/api/restaurants/filter?city=Auckland
+- Open Now (NZ time):
+  api/restaurants/filter?openNow=true
 
-Filter by multiple cities:
-/api/restaurants/filter?city=Auckland&city=Wellington
+- Filter by one city:
+  /api/restaurants/filter?city=Auckland
 
-Combine filters:
-/api/restaurants/filter?city=Auckland&cuisine=Japanese&priceMax=3&openNow=true
-OR
-/api/restaurants/filter?query=ramen&cuisine=Japanese&city=Auckland
+- Filter by multiple cities:
+  /api/restaurants/filter?city=Auckland&city=Wellington
 
-** How to test in browser**
+- Combine filters:
+  /api/restaurants/filter?city=Auckland&cuisine=Japanese&priceMax=3&openNow=true
+  OR
+  /api/restaurants/filter?query=ramen&cuisine=Japanese&city=Auckland
+
+**How to test in browser**
 http://localhost:8080/api/restaurants/filter?city=Auckland&openNow=true
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,3 +215,55 @@ All issues are encouraged to follow a consistent naming pattern:
 - If you need help, comment on the relevant issue or PR and tag teammates.
 
 ---
+
+## Search Filter API
+
+All filterable search is done via:
+GET /api/restaurants/filter
+
+**Query Parameters**
+All params are **optional** and **combinable**.
+
+| Param         | Type               | Example                         | Notes                                                                                                                  |
+| ------------- | ------------------ | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `query`       | `string`           | `query=pizza`                   | Keyword match on `name`, `description`, `cuisine` (case-insensitive). Applied **in-memory** after structured filters.  |
+| `cuisine`     | `string`           | `cuisine=Italian`               | Case-insensitive partial match.                                                                                        |
+| `priceMin`    | `number` (1–5)     | `priceMin=2`                    | Filters `price_level >= priceMin`.                                                                                     |
+| `priceMax`    | `number` (1–5)     | `priceMax=4`                    | Filters `price_level <= priceMax`. Swaps values if `priceMin > priceMax`.                                              |
+| `reservation` | `boolean`          | `reservation=true`              | Matches `reservation_required`.                                                                                        |
+| `openNow`     | `boolean`          | `openNow=true`                  | Uses **Pacific/Auckland** time; parses `hours[day]` like `11:00-22:00`, handles overnight spans (e.g., `18:00-02:00`). |
+| `city`        | `string[]` (multi) | `city=Auckland&city=Wellington` | Exact (case-insensitive) match on `address.city`. Pass multiple `city` params for OR matching.                         |
+
+> Pagination: **not implemented yet**. You’ll get the full filtered list.
+
+**Quick Examples**
+Basic Keyword Search:
+/api/restaurants/filter?query=sushi
+
+By cuisine:
+/api/restaurants/filter?cuisine=Italian
+
+Price range:
+/api/restaurants/filter?priceMin=2&priceMax=4
+
+Reservation Required:
+/api/restaurants/filter?reservation=true
+
+Open Now (NZ time):
+api/restaurants/filter?openNow=true
+
+Filter by one city:
+/api/restaurants/filter?city=Auckland
+
+Filter by multiple cities:
+/api/restaurants/filter?city=Auckland&city=Wellington
+
+Combine filters:
+/api/restaurants/filter?city=Auckland&cuisine=Japanese&priceMax=3&openNow=true
+OR
+/api/restaurants/filter?query=ramen&cuisine=Japanese&city=Auckland
+
+** How to test in browser**
+http://localhost:8080/api/restaurants/filter?city=Auckland&openNow=true
+
+---

--- a/backend/src/main/java/com/plateful/backend/restaurant/RestaurantController.java
+++ b/backend/src/main/java/com/plateful/backend/restaurant/RestaurantController.java
@@ -10,14 +10,20 @@ import java.util.stream.Collectors;
 public class RestaurantController {
 
   private final RestaurantRepository repo;
+  private final RestaurantSearchService searchService;
 
-  public RestaurantController(RestaurantRepository repo) { this.repo = repo; }
+  public RestaurantController(RestaurantRepository repo, RestaurantSearchService searchService) {
+    this.repo = repo;
+    this.searchService = searchService;
+  }
 
+  /** Get all restaurants (no filters) */
   @GetMapping
   public List<Restaurant> list() {
     return repo.findAll();
   }
 
+  /** Get a single restaurant by id */
   @GetMapping("/{id}")
   public Restaurant get(@PathVariable String id) {
     return repo.findById(id).orElseThrow(() -> new RuntimeException("Not found: " + id));
@@ -32,6 +38,54 @@ public class RestaurantController {
         query, query, query);
   }
 
+  // @GetMapping("/filter")
+  // public List<Restaurant> filter(
+  //         @RequestParam(required = false) String query,
+  //         @RequestParam(required = false) String cuisine,
+  //         @RequestParam(required = false) Integer priceMin,
+  //         @RequestParam(required = false) Integer priceMax,
+  //         @RequestParam(required = false) Boolean reservation,
+  //         @RequestParam(required = false) Boolean openNow
+  // ) {
+  //   // If keyword search is provided, run text search first
+  //   if (query != null && !query.isBlank()) {
+  //       return repo.findByNameContainingIgnoreCaseOrDescriptionContainingIgnoreCaseOrCuisineContainingIgnoreCase(
+  //               query, query, query
+  //       );
+  //   }
+
+  //   // Otherwise run structured filter
+  //   return searchService.filter(cuisine, priceMin, priceMax, reservation, openNow);
+  // }
+
+  @GetMapping("/filter")
+  public List<Restaurant> filter(
+      @RequestParam(required = false) String query,
+      @RequestParam(required = false) String cuisine,
+      @RequestParam(required = false) Integer priceMin,
+      @RequestParam(required = false) Integer priceMax,
+      @RequestParam(required = false) Boolean reservation,
+      @RequestParam(required = false) Boolean openNow,
+      @RequestParam(required = false) List<String> city
+  ) {
+    List<Restaurant> base = searchService.filter(
+      cuisine, priceMin, priceMax, reservation, openNow, city
+  );
+
+  if (query != null && !query.isBlank()) {
+    String q = query.trim().toLowerCase();
+    base = base.stream()
+        .filter(r ->
+            containsIgnoreCase(r.getName(), q) ||
+            containsIgnoreCase(r.getDescription(), q) ||
+            containsIgnoreCase(r.getCuisine(), q)
+        )
+        .collect(java.util.stream.Collectors.toList());
+  }
+
+  return base;
+  }
+
   @GetMapping("/cuisines")
   public List<String> getCuisines() {
     return repo.findAllCuisines()
@@ -41,5 +95,9 @@ public class RestaurantController {
         .distinct()
         .sorted()
         .collect(Collectors.toList());
+  }
+
+  private static boolean containsIgnoreCase(String s, String needleLower) {
+    return s != null && s.toLowerCase().contains(needleLower);
   }
 }

--- a/backend/src/main/java/com/plateful/backend/restaurant/RestaurantController.java
+++ b/backend/src/main/java/com/plateful/backend/restaurant/RestaurantController.java
@@ -38,26 +38,6 @@ public class RestaurantController {
         query, query, query);
   }
 
-  // @GetMapping("/filter")
-  // public List<Restaurant> filter(
-  //         @RequestParam(required = false) String query,
-  //         @RequestParam(required = false) String cuisine,
-  //         @RequestParam(required = false) Integer priceMin,
-  //         @RequestParam(required = false) Integer priceMax,
-  //         @RequestParam(required = false) Boolean reservation,
-  //         @RequestParam(required = false) Boolean openNow
-  // ) {
-  //   // If keyword search is provided, run text search first
-  //   if (query != null && !query.isBlank()) {
-  //       return repo.findByNameContainingIgnoreCaseOrDescriptionContainingIgnoreCaseOrCuisineContainingIgnoreCase(
-  //               query, query, query
-  //       );
-  //   }
-
-  //   // Otherwise run structured filter
-  //   return searchService.filter(cuisine, priceMin, priceMax, reservation, openNow);
-  // }
-
   @GetMapping("/filter")
   public List<Restaurant> filter(
       @RequestParam(required = false) String query,

--- a/backend/src/main/java/com/plateful/backend/restaurant/RestaurantSearchService.java
+++ b/backend/src/main/java/com/plateful/backend/restaurant/RestaurantSearchService.java
@@ -1,0 +1,116 @@
+package com.plateful.backend.restaurant;
+
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RestaurantSearchService {
+
+    private final MongoTemplate mongoTemplate;
+
+    public RestaurantSearchService(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    public List<Restaurant> filter(
+            String cuisine,
+            Integer priceMin,
+            Integer priceMax,
+            Boolean reservation,
+            Boolean openNow,
+            List<String> cities
+    ) {
+        List<Criteria> ands = new ArrayList<>();
+
+        if (cuisine != null && !cuisine.isBlank()) {
+            ands.add(Criteria.where("cuisine").regex(cuisine, "i"));
+        }
+
+        if (priceMin != null || priceMax != null) {
+            Criteria c = Criteria.where("price_level");
+            if (priceMin != null && priceMax != null && priceMin > priceMax) {
+                int tmp = priceMin; priceMin = priceMax; priceMax = tmp;
+            }
+            if (priceMin != null) c = c.gte(priceMin);
+            if (priceMax != null) c = c.lte(priceMax);
+            ands.add(c);
+        }
+
+        if (reservation != null) {
+            ands.add(Criteria.where("reservation_required").is(reservation));
+        }
+
+        if (cities != null && !cities.isEmpty()) {
+            // Normalise and build case-insensitive OR over address.city
+            List<Criteria> cityOr = new ArrayList<>();
+            for (String city : cities) {
+                if (city != null && !city.isBlank()) {
+                    cityOr.add(Criteria.where("address.city").regex("^" + java.util.regex.Pattern.quote(city.trim()) + "$", "i"));
+                }
+            }
+            if (!cityOr.isEmpty()) {
+                ands.add(new Criteria().orOperator(cityOr.toArray(new Criteria[0])));
+            }
+        }
+
+
+        Query query = new Query();
+        if (!ands.isEmpty()) {
+            query.addCriteria(new Criteria().andOperator(ands.toArray(new Criteria[0])));
+        }
+
+        List<Restaurant> results = mongoTemplate.find(query, Restaurant.class);
+
+        if (Boolean.TRUE.equals(openNow)) {
+            ZoneId nz = ZoneId.of("Pacific/Auckland");
+            LocalTime now = LocalTime.now(nz);
+            String dayKey = dayKeyNZ(nz);
+
+            results = results.stream()
+                    .filter(r -> isOpenNow(r, dayKey, now))
+                    .collect(Collectors.toList());
+        }
+
+        return results;
+    }
+
+    private static String dayKeyNZ(ZoneId nz) {
+        String[] keys = {"monday","tuesday","wednesday","thursday","friday","saturday","sunday"};
+        int idx = java.time.ZonedDateTime.now(nz).getDayOfWeek().getValue();
+        return keys[idx - 1];
+    }
+
+    //Check if the restaurant is open now - using nztimezone
+    private static boolean isOpenNow(Restaurant r, String dayKey, LocalTime now) {
+        Map<String, String> hours = r.getHours();
+        if (hours == null) return false;
+        String span = hours.get(dayKey);
+        if (span == null || span.isBlank()) return false;
+
+        String[] parts = span.split("-");
+        if (parts.length != 2) return false;
+
+        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("HH:mm");
+        try {
+            LocalTime start = LocalTime.parse(parts[0].trim(), fmt);
+            LocalTime end   = LocalTime.parse(parts[1].trim(), fmt);
+
+            if (end.isAfter(start) || end.equals(start)) {
+                return !now.isBefore(start) && !now.isAfter(end);
+            } else {
+                // overnight window
+                return !now.isBefore(start) || !now.isAfter(end);
+            }
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Implemented restaurant filtering support in the backend (/api/restaurants/filter). Users can now filter restaurants using multiple query parameters to refine results.

**Changes**

- Added /filter endpoint in RestaurantController
- Implemented filtering logic in RestaurantSearchService using MongoTemplate
- Added unit tests for /filter in RestaurantControllerTest
- Updated documentation with usage examples at the end of the contribution guidelines

**Supported filters:**

- query → keyword match in name/description/cuisine
- cuisine → filter by cuisine type (case-insensitive)
- priceMin / priceMax → filter by price level range (1–5)
- reservation → filter by reservation requirement (true/false)
- openNow → filter only restaurants currently open (NZ time)
- city → filter by one or multiple cities (comma-separated)

**How to Test:**
1.  Run backend `mvn spring-boot:run`
2. Call the new endpoint, for example:
- GET http://localhost:8080/api/restaurants/filter?cuisine=Italian
- GET http://localhost:8080/api/restaurants/filter?priceMin=2&priceMax=4
- GET http://localhost:8080/api/restaurants/filter?reservation=true&openNow=true
- GET http://localhost:8080/api/restaurants/filter?city=Auckland,Wellington
3. Verify results match the expected filters

**Issue Link**
Closes #14 