### PR TITLE
Upgrade springboot version to 3.5.5

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.plateful</groupId>


### PR DESCRIPTION
This pull request updates the version of the Spring Boot starter parent dependency in the `backend/pom.xml` file to keep the project up-to-date with the latest bug fixes and improvements.

Dependency update:

* Upgraded Spring Boot starter parent version from `3.5.4` to `3.5.5` in `backend/pom.xml` to ensure the project uses the most recent stable release.

Relevant issue: #60 