### PR TITLE
Fix/license and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-cdin152@aucklanduni.ac.nz.
+k.blincoe@auckland.ac.nz.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Connie Ding
+Copyright (c) 2025 DCML
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Description 
This PR updates the repository metadata to reflect new ownership and contact details. Specifically, the GitHub license file has been renamed to align with the updated project identity, and the Code of Conduct has been revised to include a new maintainer contact email. These changes help clarify project stewardship and ensure contributors know where to direct questions or concerns.

Changes Made
- Renamed the GitHub license file to reflect the updated company name.
- Updated the contact email in the Code of Conduct to a new maintainer address.