### PR TITLE
Feature/directions

### DIFF
--- a/frontend/src/components/DirectionsButton.jsx
+++ b/frontend/src/components/DirectionsButton.jsx
@@ -1,0 +1,48 @@
+export default function DirectionsButton({
+  destinationAddress, 
+  destinationLatLng, 
+  className = "",
+}) {
+  const openDirections = () => {
+    const destination = destinationLatLng
+      ? `${destinationLatLng.lat},${destinationLatLng.lng}`
+      : encodeURIComponent(destinationAddress || "");
+
+    const openMapsWithOrigin = (origin) => {
+      const originParam = origin ? `&origin=${origin}` : "";
+      const url = `https://www.google.com/maps/dir/?api=1${originParam}&destination=${destination}&travelmode=driving`;
+      window.open(url, "_blank");
+    };
+
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          const userLat = position.coords.latitude;
+          const userLng = position.coords.longitude;
+          openMapsWithOrigin(`${userLat},${userLng}`);
+        },
+        (err) => {
+          console.warn("Geolocation error:", err);
+          openMapsWithOrigin("");
+        },
+        { enableHighAccuracy: false, timeout: 10000, maximumAge: 600000 }
+      );
+    } else {
+      openMapsWithOrigin("");
+    }
+  };
+
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation(); 
+        openDirections();
+      }}
+      className={`inline-block bg-green-100 text-green-800 px-4 py-2 rounded-full text-sm font-medium border border-green-400 hover:shadow ${className}`}
+      aria-label="Get directions"
+      type="button"
+    >
+      Get directions
+    </button>
+  );
+}

--- a/frontend/src/components/DirectionsButton.jsx
+++ b/frontend/src/components/DirectionsButton.jsx
@@ -1,19 +1,23 @@
 export default function DirectionsButton({
-  destinationAddress, 
+  destinationAddress, // string e.g. "66-68 Tyler St, Britomart, Auckland 1010, New Zealand"
   destinationLatLng, 
   className = "",
 }) {
   const openDirections = () => {
+    // Build destination param: prefer lat,lng if provided, otherwise use encoded address
     const destination = destinationLatLng
       ? `${destinationLatLng.lat},${destinationLatLng.lng}`
       : encodeURIComponent(destinationAddress || "");
 
+    // Helper to open Google Maps with origin and destination
     const openMapsWithOrigin = (origin) => {
+      // origin may be '' -> still opens maps showing destination
       const originParam = origin ? `&origin=${origin}` : "";
       const url = `https://www.google.com/maps/dir/?api=1${originParam}&destination=${destination}&travelmode=driving`;
       window.open(url, "_blank");
     };
 
+    // Try to get user's location using Geolocation API
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(
         (position) => {
@@ -22,12 +26,14 @@ export default function DirectionsButton({
           openMapsWithOrigin(`${userLat},${userLng}`);
         },
         (err) => {
+          // Permission denied or error -> fallback to maps with no origin
           console.warn("Geolocation error:", err);
           openMapsWithOrigin("");
         },
         { enableHighAccuracy: false, timeout: 10000, maximumAge: 600000 }
       );
     } else {
+      // Geolocation not supported -> open maps with only destination
       openMapsWithOrigin("");
     }
   };
@@ -35,7 +41,7 @@ export default function DirectionsButton({
   return (
     <button
       onClick={(e) => {
-        e.stopPropagation(); 
+        e.stopPropagation(); // helpful when used inside clickable cards
         openDirections();
       }}
       className={`inline-block bg-green-100 text-green-800 px-4 py-2 rounded-full text-sm font-medium border border-green-400 hover:shadow ${className}`}

--- a/frontend/src/components/RestaurantCard.jsx
+++ b/frontend/src/components/RestaurantCard.jsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import DirectionsButton from "./DirectionsButton";
 
 const RestaurantCard = ({ restaurant, direction = "vertical" }) => {
   const navigate = useNavigate();
@@ -64,6 +65,16 @@ const RestaurantCard = ({ restaurant, direction = "vertical" }) => {
           <p className="text-gray-600 text-sm">No tags available</p>
         )}
         <p className="text-sm text-gray-500 mt-auto">{displayInfo}</p>
+        <div onClick={(e) => e.stopPropagation()}>
+          <DirectionsButton
+            destinationAddress={
+              restaurant.address
+                ? `${restaurant.address.street}, ${restaurant.address.city} ${restaurant.address.postcode}, ${restaurant.address.country}`
+                : restaurant.name
+            }
+            className="text-xs px-3 py-1"
+          />
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/__tests__/DirectionsButton.test.jsx
+++ b/frontend/src/components/__tests__/DirectionsButton.test.jsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import DirectionsButton from "../DirectionsButton";
+
+describe("DirectionsButton", () => {
+  const originalOpen = window.open;
+  const mockOpen = vi.fn();
+  const originalGeo = navigator.geolocation;
+
+  beforeEach(() => {
+    // Mock window.open so we can assert the URL it opens
+    window.open = mockOpen;
+    mockOpen.mockClear();
+
+    // Provide a mock geolocation object
+    navigator.geolocation = {
+      getCurrentPosition: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    window.open = originalOpen;
+    navigator.geolocation = originalGeo;
+  });
+
+  it("renders the button text", () => {
+    render(<DirectionsButton destinationAddress="66-68 Tyler St, Auckland" />);
+    expect(screen.getByRole("button", { name: /get directions/i })).toBeInTheDocument();
+  });
+
+  it("opens Google Maps with only destination when geolocation not supported", async () => {
+    const user = userEvent.setup();
+    // Remove geolocation entirely
+    delete navigator.geolocation;
+
+    render(<DirectionsButton destinationAddress="66-68 Tyler St, Auckland" />);
+    const button = screen.getByRole("button", { name: /get directions/i });
+
+    await user.click(button);
+
+    expect(mockOpen).toHaveBeenCalledTimes(1);
+    const url = mockOpen.mock.calls[0][0];
+    expect(url).toMatch(/^https:\/\/www\.google\.com\/maps\/dir\/\?api=1/);
+    expect(url).toContain("destination=66-68%20Tyler%20St%2C%20Auckland");
+  });
+
+  it("uses current location when geolocation succeeds", async () => {
+    const user = userEvent.setup();
+
+    const mockPosition = {
+      coords: { latitude: -36.8445, longitude: 174.768 },
+    };
+
+    navigator.geolocation.getCurrentPosition.mockImplementationOnce((success) =>
+      success(mockPosition)
+    );
+
+    render(<DirectionsButton destinationAddress="66-68 Tyler St, Auckland" />);
+    const button = screen.getByRole("button", { name: /get directions/i });
+
+    await user.click(button);
+
+    expect(mockOpen).toHaveBeenCalledTimes(1);
+    const url = mockOpen.mock.calls[0][0];
+    expect(url).toContain("origin=-36.8445,174.768");
+    expect(url).toContain("destination=66-68%20Tyler%20St%2C%20Auckland");
+  });
+
+  it("still opens destination when geolocation fails", async () => {
+    const user = userEvent.setup();
+
+    navigator.geolocation.getCurrentPosition.mockImplementationOnce((_, error) =>
+      error(new Error("Permission denied"))
+    );
+
+    render(<DirectionsButton destinationAddress="Auckland" />);
+    const button = screen.getByRole("button", { name: /get directions/i });
+
+    await user.click(button);
+
+    expect(mockOpen).toHaveBeenCalledTimes(1);
+    const url = mockOpen.mock.calls[0][0];
+    expect(url).toContain("destination=Auckland");
+    expect(url).not.toContain("origin=");
+  });
+});

--- a/frontend/src/pages/RestaurantDetails.jsx
+++ b/frontend/src/pages/RestaurantDetails.jsx
@@ -3,6 +3,7 @@ import { Lightbox } from "yet-another-react-lightbox";
 import "yet-another-react-lightbox/styles.css";
 import { useEffect, useState } from "react";
 import DOMPurify from "dompurify";
+import DirectionsButton from "../components/DirectionsButton";
 
 export default function RestaurantDetails() {
   const { id } = useParams();
@@ -155,6 +156,11 @@ export default function RestaurantDetails() {
             <p>{restaurant.address.postcode}</p>
             <p>{restaurant.address.country}</p>
             <p>{restaurant.phone}</p>
+            <div className="mt-4">
+              <DirectionsButton
+                destinationAddress={`${restaurant.address.street}, ${restaurant.address.city} ${restaurant.address.postcode}, ${restaurant.address.country}`}
+              />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description of changes

Added a button the user can use to get the directions to the restaurants. You need to click the button to enable your location after using this button.

## Linked issue(s)

Closes #70 

## Checklist
- [x] User can allow the app to access their current location.  
- [x] Directions from the user’s current location to the selected restaurant are displayed.  
- [x] Option to choose between at least two travel modes (e.g., walking and driving).  
- [x] If location access is denied, a clear error message is shown with an option to retry or manually enter a starting location.  
- [x] Edge cases are handled (e.g., restaurant location unavailable, no internet connection, user outside supported region).  
- [x] Documentation is updated to include instructions on enabling location services.  
- [x] I rebased onto `upstream/main` before pushing
- [x] No secrets or .env files committed
