### PR TITLE
closing issue #127 preventing database errors from breaking map rendering

### DIFF
--- a/frontend/src/components/RestaurantMarkers.jsx
+++ b/frontend/src/components/RestaurantMarkers.jsx
@@ -32,9 +32,15 @@ export default function RestaurantMarkers({ map, restaurants }) {
 
     restaurants.forEach((r) => {
       try {
-        const lng = r.location?.coordinates?.[0] ?? r.longitude;
-        const lat = r.location?.coordinates?.[1] ?? r.latitude;
+          // TODO: Remove this when Database Entries are fixed
+          let lng = Number(r.location?.coordinates?.[0] ?? r.longitude);
+          let lat = Number(r.location?.coordinates?.[1] ?? r.latitude);
+
         if (lng == null || lat == null) return;
+        // If it looks like [lat, lng] or ranges are invalid, swap them.
+        if ((Math.abs(lng) <= 90 && Math.abs(lat) > 90) || lng < -180 || lng > 180 || lat < -90 || lat > 90) {
+            [lng, lat] = [lat, lng];
+        }
 
         const el = document.createElement("div");
         el.className = "custom-marker";


### PR DESCRIPTION
## Description of changes

Adds a lang longitude force if they are outside of an expected range, and swaps them, this is to prevent data entry errors affecting the map pin rendering

## Linked issue(s)
Closes #127

## Files changed

ResturantMarkers.jsx

added a logical checker for longitude and lattitude numbers

## Checklist

- [x] I rebased onto `upstream/main` before pushing
- [ ] No secrets or .env files committed
