### PR TITLE
Add SonarQube configuration for project analysis and coverage reporting

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -32,7 +32,34 @@
   </scm>
   <properties>
     <java.version>17</java.version>
+    <sonar.projectKey>UOA-DCML_se310-plateful</sonar.projectKey>
     <sonar.organization>uoa-dcml</sonar.organization>
+    <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+    <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+    
+    <!-- Exclude DTOs, configs, models, controllers, auth, and specific services from coverage -->
+    <sonar.coverage.exclusions>
+      **/dto/**/*.java,
+      **/config/**/*.java,
+      **/model/**/*.java,
+      **/controller/**/*.java,
+      **/auth/**/*.java,
+      **/ServletInitializer.java,
+      **/BackendApplication.java,
+      **/exception/**/*.java,
+      **/service/RestaurantSearchService.java,
+      **/service/VotingQueryService.java,
+      **/service/VotingService.java
+    </sonar.coverage.exclusions>
+    
+    <!-- Also exclude from duplication analysis -->
+    <sonar.cpd.exclusions>
+      **/dto/**/*.java,
+      **/model/**/*.java
+    </sonar.cpd.exclusions>
+    
+    <!-- Set minimum coverage thresholds -->
+    <sonar.coverage.minimum>25.0</sonar.coverage.minimum>
   </properties>
 
   <dependencies>
@@ -115,6 +142,26 @@
         <groupId>org.sonarsource.scanner.maven</groupId>
         <artifactId>sonar-maven-plugin</artifactId>
         <version>5.1.0.4751</version>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.12</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,72 @@
+# SonarQube Configuration for Plateful Project
+
+# Project identification
+sonar.projectKey=UOA-DCML_se310-plateful
+sonar.organization=uoa-dcml
+
+# Project metadata
+sonar.projectName=Plateful
+sonar.projectVersion=1.0
+
+# Source code locations
+sonar.sources=backend/src/main/java,frontend/src
+sonar.tests=backend/src/test/java,frontend/src/__tests__,frontend/src/components/__tests__,frontend/src/pages/__tests__
+
+# Java settings
+sonar.java.source=17
+sonar.java.binaries=backend/target/classes
+sonar.java.libraries=backend/target/**/*.jar
+
+# Coverage reports
+sonar.coverage.jacoco.xmlReportPaths=backend/target/site/jacoco/jacoco.xml
+sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info
+
+# Exclusions from analysis
+sonar.exclusions=\
+  **/node_modules/**,\
+  **/target/**,\
+  **/dist/**,\
+  **/build/**,\
+  **/*.test.js,\
+  **/*.test.jsx,\
+  **/*.spec.js,\
+  **/*.spec.jsx
+
+# Coverage exclusions (don't require tests for these)
+# Exclude these patterns from coverage analysis
+sonar.coverage.exclusions=\
+  **/node_modules/**,\
+  **/target/**,\
+  **/*.test.js,\
+  **/*.test.jsx,\
+  **/*.spec.js,\
+  **/*.spec.jsx,\
+  **/test/**,\
+  **/tests/**,\
+  **/__tests__/**,\
+  **/dto/**/*.java,\
+  **/config/**/*.java,\
+  **/model/**/*.java,\
+  **/controller/**/*.java,\
+  **/auth/**/*.java,\
+  **/exception/**/*.java,\
+  **/ServletInitializer.java,\
+  **/BackendApplication.java,\
+  **/service/RestaurantSearchService.java,\
+  **/service/VotingQueryService.java,\
+  **/service/VotingService.java,\
+  **/main.jsx,\
+  **/index.css,\
+  **/vite.config.js,\
+  **/vitest.setup.js,\
+  **/tailwind.config.js,\
+  **/eslint.config.js,\
+  **/*Context.jsx,\
+  **/Layout.jsx,\
+  **/App.jsx
+
+# Source encoding
+sonar.sourceEncoding=UTF-8
+
+# Quality Gate thresholds
+sonar.qualitygate.wait=false


### PR DESCRIPTION
This pull request introduces SonarCloud and JaCoCo integration for code quality and coverage analysis in the project, with configuration changes to both the Maven build (`pom.xml`) and a new `sonar-project.properties` file. The most important changes are grouped below by theme.

**SonarCloud and Coverage Integration:**

* Added SonarCloud project and organization configuration, coverage report paths, and exclusion rules for DTOs, configs, models, controllers, authentication, exceptions, and specific services to the Maven `pom.xml` properties section. Also set a minimum coverage threshold of 25%.
* Added the JaCoCo Maven plugin to `pom.xml` for automated test coverage reporting, including agent preparation and report generation during the test phase.

**Project-wide SonarCloud Configuration:**

* Created a new `sonar-project.properties` file to define project identification, source and test locations, Java and JavaScript coverage report paths, analysis and coverage exclusions for both backend and frontend, and quality gate settings.